### PR TITLE
fix: use `vim.inspect` if available in environment

### DIFF
--- a/lua/neotest-bun/init.lua
+++ b/lua/neotest-bun/init.lua
@@ -201,7 +201,7 @@ Adapter = {
 			formatted_results[formatted_key] = result
 		end
 
-		local inspect = require("inspect")
+		local inspect = vim and vim.inspect or require("inspect")
 
 		-- Debug: Write XML content and parsed results to files for debugging
 		local debug_file_xml = io.open("./neotest-bun-debug-xml.txt", "w")


### PR DESCRIPTION
The original code unconditionally called require("inspect"), which would fail in Neovim environments where the external inspect library is not installed. This change prioritizes vim.inspect (built-in to Neovim) when available, falling back to require("inspect") for standalone Lua environments that have the inspect library installed.

You can see the other 4 forks with "fixes" by commenting out this line... should fix #2 